### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,12 +42,12 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.4-e37d33cc-v2"
+              "version": "idf-release_v5.3-d5b84196-v1"
             },
             {
               "packager": "esp32",
               "name": "xtensa-esp-elf-gcc",
-              "version": "esp-14.2.0_20241119"
+              "version": "esp-13.2.0_20240530"
             },
             {
               "packager": "esp32",
@@ -57,7 +57,7 @@
             {
               "packager": "esp32",
               "name": "riscv32-esp-elf-gcc",
-              "version": "esp-14.2.0_20241119"
+              "version": "esp-13.2.0_20240530"
             },
             {
               "packager": "esp32",
@@ -95,125 +95,125 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.4-e37d33cc-v2",
+          "version": "idf-release_v5.3-d5b84196-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/esp32-arduino-lib-builder/releases/download/idf-release_v5.4/esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.4-e37d33cc-v2.zip",
-              "checksum": "SHA-256:815e53a44eb4e0b59335b97cc0f66ad76a48ea61013dff5289db169f0bb8631c",
-              "size": "339629117"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
+              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
+              "size": "61655869"
             }
           ]
         },
         {
           "name": "xtensa-esp-elf-gcc",
-          "version": "esp-14.2.0_20241119",
+          "version": "esp-13.2.0_20240530",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:b1859df334a85541ae746e1b86439f59180d87f8cf1cc04c2e770fadf9f006e9",
-              "size": "323678089"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:bce77e8480701d5a90545369d1b5848f6048eb39c0022d2446d1e33a8e127490",
+              "size": "208911713"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:7ff023033a5c00e55b9fc0a0b26d18fb0e476c24e24c5b0459bcb2e05a3729f1",
-              "size": "320064691"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:7c9e3c1adc733d042ed87b92daa1d6396e1b441c1755f1fa14cb88855719ba88",
+              "size": "202519931"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:bb11dbf3ed25d4e0cc9e938749519e8236cfa2609e85742d311f1d869111805a",
-              "size": "319454139"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:d6955e8ea6af91574bf9213b92f32ca09eb8640103446b7fa19a63cfeeec5421",
+              "size": "202206516"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:5ac611dca62ec791d413d1f417d566c444b006d2a4f97bd749b15f782d87249b",
-              "size": "328335914"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:3666ee74ecb693ee6488f11469802630a7b0d32608184045a4f35cb413f59e3d",
+              "size": "213304863"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
-              "checksum": "SHA-256:15b3e60362028eaeff9156dc82dac3f1436b4aeef3920b28d7650974d8c34751",
-              "size": "336215844"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
+              "checksum": "SHA-256:948cf57b6eecc898b5f70e06ad08ba88c08b627be570ec631dfcd72f6295194a",
+              "size": "221357024"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
-              "checksum": "SHA-256:45c475518735133789bacccad31f872318b7ecc0b31cc9b7924aad880034f0bf",
-              "size": "318797396"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
+              "checksum": "SHA-256:6f03fdf0cc14a7f3900ee59977f62e8626d8b7c208506e52f1fd883ac223427a",
+              "size": "199689745"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:b30e450e0af279783c54a9ae77c3b367dd556b78eda930a92ec7b784a74c28c8",
-              "size": "382457717"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-i686-w64-mingw32_hotfix.zip",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-i686-w64-mingw32_hotfix.zip",
+              "checksum": "SHA-256:d6b227c50e3c8e21d62502b3140e5ab74a4cb502c2b4169c36238b9858a8fb88",
+              "size": "266042967"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
-              "archiveFileName": "xtensa-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:62ae704777d73c30689efff6e81178632a1ca44d1a2d60f4621eb997e040e028",
-              "size": "386316009"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/xtensa-esp-elf-13.2.0_20240530-x86_64-w64-mingw32_hotfix.zip",
+              "archiveFileName": "xtensa-esp-elf-13.2.0_20240530-x86_64-w64-mingw32_hotfix.zip",
+              "checksum": "SHA-256:155ee97b531236e6a7c763395c68ca793e55e74d2cb4d38a23057a153e01e7d0",
+              "size": "269831985"
             }
           ]
         },
@@ -281,63 +281,63 @@
         },
         {
           "name": "riscv32-esp-elf-gcc",
-          "version": "esp-14.2.0_20241119",
+          "version": "esp-13.2.0_20240530",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:a16942465d33c7f0334c16e83bc6feb62e06eeb79cf19099293480bb8d48c0cd",
-              "size": "593721156"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:e7fbfffbb19dcd3764a9848a141bf44e19ad0b48e0bd1515912345c26fe52fba",
+              "size": "294346758"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-aarch64-linux-gnu.tar.gz",
-              "checksum": "SHA-256:22486233d0e0fd58a54ae453b701f195f1432fc6f2e17085b9d6c8d5d9acefb7",
-              "size": "587879927"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-aarch64-linux-gnu.tar.gz",
+              "checksum": "SHA-256:a178a895b807ed2e87d5d62153c36a6aae048581f527c0eb152f0a02b8de9571",
+              "size": "288374597"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-arm-linux-gnueabi.tar.gz",
-              "checksum": "SHA-256:27a72d5d96cdb56dae2a1da5dfde1717c18a8c1f9a1454c8e34a8bd34abe662d",
-              "size": "586531522"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-arm-linux-gnueabi.tar.gz",
+              "checksum": "SHA-256:4a2f176d0f5bc8a70645975e2a08ea94145fb69b7225c5cdcbd6024a4836aaf5",
+              "size": "287737495"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-i586-linux-gnu.tar.gz",
-              "checksum": "SHA-256:b7bd6e4cd53a4c55831d48e96a3d500bfffb091bec84a30bc8c3ad687e3eb3a2",
-              "size": "597070471"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-i586-linux-gnu.tar.gz",
+              "checksum": "SHA-256:7a6f02f1b2effafb18600bbf602818f6923fd320f000fb8659f34acbfda8812f",
+              "size": "299138540"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-apple-darwin_signed.tar.gz",
-              "checksum": "SHA-256:5f8b571e1aedbe9f856f3bdeca6600cd5510ccff1ca102c4f001421eda560585",
-              "size": "602343061"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-apple-darwin.tar.gz",
+              "checksum": "SHA-256:a193b4f025d0d836b0a9d9cbe760af1c53e53af66fc332fe98952bc4c456dd9a",
+              "size": "305025700"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-aarch64-apple-darwin_signed.tar.gz",
-              "checksum": "SHA-256:a7276042a7eb2d33c2dff7167539e445c32c07d43a2c6827e86d035642503e0b",
-              "size": "578521565"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-aarch64-apple-darwin.tar.gz",
+              "checksum": "SHA-256:7082dd2e2123dea5609a24092d19ac6612ae7e219df1d298de6b2f64cb4af0df",
+              "size": "285458443"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-i686-w64-mingw32.zip",
-              "checksum": "SHA-256:54193a97bd75205678ead8d11f00b351cfa3c2a6e5ab5d966341358b9f9422d7",
-              "size": "672055172"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-i686-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-i686-w64-mingw32.zip",
+              "checksum": "SHA-256:590bfb10576702639825581cc00c445da6e577012840a787137417e80d15f46d",
+              "size": "366573064"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
-              "archiveFileName": "riscv32-esp-elf-14.2.0_20241119-x86_64-w64-mingw32.zip",
-              "checksum": "SHA-256:24c8407fa467448d394e0639436a5ede31caf1838e35e8435e19df58ebed438c",
-              "size": "677812937"
+              "url": "https://github.com/espressif/crosstool-NG/releases/download/esp-13.2.0_20240530/riscv32-esp-elf-13.2.0_20240530-x86_64-w64-mingw32.zip",
+              "archiveFileName": "riscv32-esp-elf-13.2.0_20240530-x86_64-w64-mingw32.zip",
+              "checksum": "SHA-256:413eb9f6adf8fdaf25544d014c850fc09eb38bb93a2fc5ebd107ab1b0de1bb3a",
+              "size": "369820297"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-d5b84196-v1"
+              "version": "idf-release_v5.3-efec039d-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-d5b84196-v1",
+          "version": "idf-release_v5.3-efec039d-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-d5b84196-v1.zip",
-              "checksum": "SHA-256:0ef3c9210477cbde71bd8a8125e38e6c511e80a960df7b37cf73eda0e352c186",
-              "size": "61655869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
+              "checksum": "SHA-256:73b6fcce74c806117247984c3604dd71d145cb0b3126fa73df7529a9e5811454",
+              "size": "61670827"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 200d29d
esp-idf: release/v5.3 d5b8419620
arduino: master fc3cbef3
tinyusb: master 4c1e28126
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.0
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.18.1
```
