### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
-              "size": "61670827"
+              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
+              "size": "61671074"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -101,57 +101,57 @@
               "host": "i686-mingw32",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "x86_64-mingw32",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "arm64-apple-darwin",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "x86_64-apple-darwin",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "x86_64-pc-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "i686-pc-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "aarch64-linux-gnu",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             },
             {
               "host": "arm-linux-gnueabihf",
               "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
               "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:66399d814d59fd3a7f9242d127f84c1b73c14403b6ac39d669957a90a233274e",
-              "size": "61670818"
+              "checksum": "SHA-256:e723093eb3faa253dd50a2a711b835c2d2a8fa4bfa5f9490fbcb756687bad005",
+              "size": "61670827"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 200d29d
esp-idf: release/v5.3 efec039d9f
arduino: idf-release/v5.3 5eec367c
tinyusb: master 4c1e28126
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.18.1
```
