### PR TITLE
IDF release/v5.3

### DIFF
--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-8bb65e6d-v1"
+              "version": "idf-release_v5.3-517e489c-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-8bb65e6d-v1",
+          "version": "idf-release_v5.3-517e489c-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
-              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
-              "size": "61671435"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
+              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
+              "size": "61680093"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-6a98af1f-v1"
+              "version": "idf-release_v5.3-8e95ca29-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-6a98af1f-v1",
+          "version": "idf-release_v5.3-8e95ca29-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
-              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
-              "size": "61762044"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
+              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
+              "size": "61762209"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-3a1bd70f-v1"
+              "version": "idf-release_v5.3-c50e49dd-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-3a1bd70f-v1",
+          "version": "idf-release_v5.3-c50e49dd-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
-              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
-              "size": "61759388"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
+              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
+              "size": "61759382"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-33eb5fc7-v1"
+              "version": "idf-release_v5.3-6a98af1f-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-33eb5fc7-v1",
+          "version": "idf-release_v5.3-6a98af1f-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
-              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
-              "size": "61763145"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-6a98af1f-v1.zip",
+              "checksum": "SHA-256:fb2d1581d21596038c1cf080f589176d5ff3beb0e864f6b97aa6c8fde997f7c7",
+              "size": "61762044"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-c50e49dd-v1"
+              "version": "idf-release_v5.3-82b1690b-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-c50e49dd-v1",
+          "version": "idf-release_v5.3-82b1690b-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-c50e49dd-v1.zip",
-              "checksum": "SHA-256:7adc3c434f1bf9c8e2f3544299729857a9760dd383edfc0aa10d48d7cbfba01e",
-              "size": "61759382"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-82b1690b-v1.zip",
+              "checksum": "SHA-256:e3d8e7b50868f2bd39e1d1ada9f1f93e7b572721f90f913a5020743e0e7da580",
+              "size": "61768389"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-ce31db18-v1"
+              "version": "idf-release_v5.3-833adbc2-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-ce31db18-v1",
+          "version": "idf-release_v5.3-833adbc2-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
-              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
-              "size": "61747342"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
+              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
+              "size": "61760299"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-833adbc2-v1"
+              "version": "idf-release_v5.3-33eb5fc7-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-833adbc2-v1",
+          "version": "idf-release_v5.3-33eb5fc7-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-833adbc2-v1.zip",
-              "checksum": "SHA-256:5602e1c4846a94564ab7fb47a272ffbce9a1b8f4a04286a86f257c859715fbd6",
-              "size": "61760299"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-33eb5fc7-v1.zip",
+              "checksum": "SHA-256:c0a690f20ce9854e9f2009c046cd0757a322704639eaaeb20acef1dd5c237cb2",
+              "size": "61763145"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-f8886ebb-v1"
+              "version": "idf-release_v5.3-ce31db18-v1"
             },
             {
               "packager": "esp32",
@@ -67,7 +67,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20241016"
+              "version": "v0.12.0-esp32-20250226"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-f8886ebb-v1",
+          "version": "idf-release_v5.3-ce31db18-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
-              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
-              "size": "61739086"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-ce31db18-v1.zip",
+              "checksum": "SHA-256:65a2f28fbaf246e5ef40dd48031d003dfa62f6d9e804cb59b883f866f6ea37a1",
+              "size": "61747342"
             }
           ]
         },
@@ -405,56 +405,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20241016",
+          "version": "v0.12.0-esp32-20250226",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:e82b0f036dc99244bead5f09a86e91bb2365cbcd1122ac68261e5647942485df",
-              "size": "2398717"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:914c726342ba5828e53f41aa454f01f317c42d8e6772d3d874593a6960fc4729",
+              "size": "2414924"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:8f8daf5bd22ec5d2fa9257b0862ec33da18ee677e023fb9a9eb17f74ce208c76",
-              "size": "2271584"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:c44ee99a9209c0234dbbcec86339fd685f5c61a763b29c33eba590bf62db2296",
+              "size": "2293923"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:bc9c020ecf20e2000f76cffa44305fd5bc44d2e688ea78cce423399d33f19767",
-              "size": "2414206"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:21ab6af3cf05f9290f4d59f1f381d5094dd2755fc528d3d2feb9334348fc0d8d",
+              "size": "2436071"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:02a2dffe801a2d005fa9e614d80ff8173395b2cb0b5d3118d0229d094a9946a7",
-              "size": "2508089"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:0b5751699e93b6d101381611c96216ddff8c7dfd16425c610993fa27993f9a0a",
+              "size": "2525387"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20241016.tar.gz",
-              "checksum": "SHA-256:c382f9e884d6565cb6089bff5f200f4810994667d885f062c3d3c5625a0fa9d6",
-              "size": "2552569"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
+              "checksum": "SHA-256:8bffbbb594b27a4971a3922792135f8c836fff26991f7f450094386920263531",
+              "size": "2568843"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win32-0.12.0-esp32-20241016.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20241016.zip",
-              "checksum": "SHA-256:3b5d615e0a72cc771a45dd469031312d5881c01d7b6bc9edb29b8b6bda8c2e90",
-              "size": "2946244"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win32-0.12.0-esp32-20250226.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250226.zip",
+              "checksum": "SHA-256:aaf3c955bb4eb47805a1ba108dfd07a8a56ce720cb40194a354362b5f0961230",
+              "size": "2960226"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20241016/openocd-esp32-win64-0.12.0-esp32-20241016.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20241016.zip",
-              "checksum": "SHA-256:5e7b2fd1947d3a8625f6a11db7a2340cf2f41ff4c61284c022c7d7c32b18780a",
-              "size": "2946244"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win64-0.12.0-esp32-20250226.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250226.zip",
+              "checksum": "SHA-256:79baf35325117a53093b62f6b9bee677dd12275d7066e3f8a274d2a80e986b6e",
+              "size": "2960225"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-60d077ea-v1"
+              "version": "idf-release_v5.3-f8886ebb-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-60d077ea-v1",
+          "version": "idf-release_v5.3-f8886ebb-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
-              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
-              "size": "61770869"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-f8886ebb-v1.zip",
+              "checksum": "SHA-256:2a4bcb2d58256c594f68b91d2d5cbc9e4b48e806826be6a348c2133508b2443f",
+              "size": "61739086"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-efec039d-v1"
+              "version": "idf-release_v5.3-8bb65e6d-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-efec039d-v1",
+          "version": "idf-release_v5.3-8bb65e6d-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-efec039d-v1.zip",
-              "checksum": "SHA-256:dedc2abb4d9891c993fc3f9b0d2d3342f82000f5ce204f57235341474726abd5",
-              "size": "61671074"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8bb65e6d-v1.zip",
+              "checksum": "SHA-256:6a430917840482a08eae1c0b7679d4275ecb8a7a6fcccb25e04594930c9894f7",
+              "size": "61671435"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-517e489c-v1"
+              "version": "idf-release_v5.3-60d077ea-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-517e489c-v1",
+          "version": "idf-release_v5.3-60d077ea-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-517e489c-v1.zip",
-              "checksum": "SHA-256:d960b8b97207f05d15744a079640b48996aedfb075ffa62411ef5a71d577daf4",
-              "size": "61680093"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-60d077ea-v1.zip",
+              "checksum": "SHA-256:4ef384f4f56eb3480a5b59cdbf193075a294b39ec55ac2c1854ed86fb2f98ace",
+              "size": "61770869"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-eaf03eec-v1"
+              "version": "idf-release_v5.3-3a1bd70f-v1"
             },
             {
               "packager": "esp32",
@@ -67,7 +67,7 @@
             {
               "packager": "esp32",
               "name": "openocd-esp32",
-              "version": "v0.12.0-esp32-20250226"
+              "version": "v0.12.0-esp32-20250422"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-eaf03eec-v1",
+          "version": "idf-release_v5.3-3a1bd70f-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
-              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
-              "size": "61763087"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-3a1bd70f-v1.zip",
+              "checksum": "SHA-256:a9257e11132eb8ea8c605fb0a2bf3c7f80b4a8f2aa041fefa4adf105a60c8254",
+              "size": "61759388"
             }
           ]
         },
@@ -405,56 +405,56 @@
         },
         {
           "name": "openocd-esp32",
-          "version": "v0.12.0-esp32-20250226",
+          "version": "v0.12.0-esp32-20250422",
           "systems": [
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:914c726342ba5828e53f41aa454f01f317c42d8e6772d3d874593a6960fc4729",
-              "size": "2414924"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-amd64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:eb1fa9b21c65b45a2200af6dcc2914e32335d37b6dbbd181778dcc0dc025e70a",
+              "size": "2445546"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:c44ee99a9209c0234dbbcec86339fd685f5c61a763b29c33eba590bf62db2296",
-              "size": "2293923"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-arm64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:f70334a9b12a75b4d943e09fa5db30973037c39dbb54d6fa9f1a7118228b3d1c",
+              "size": "2330926"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:21ab6af3cf05f9290f4d59f1f381d5094dd2755fc528d3d2feb9334348fc0d8d",
-              "size": "2436071"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-linux-armel-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:4ac34d6fd1af86aeda87c8318732f8d691c300c285c7fd2f5037c432c63fbbb3",
+              "size": "2470732"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:0b5751699e93b6d101381611c96216ddff8c7dfd16425c610993fa27993f9a0a",
-              "size": "2525387"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:9186a7a06304c6d9201cbce4ee3c7099b393bf8d329cda17a68874f92308f6ce",
+              "size": "2548730"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
-              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250226.tar.gz",
-              "checksum": "SHA-256:8bffbbb594b27a4971a3922792135f8c836fff26991f7f450094386920263531",
-              "size": "2568843"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
+              "archiveFileName": "openocd-esp32-macos-arm64-0.12.0-esp32-20250422.tar.gz",
+              "checksum": "SHA-256:2cc39318d52f393233ff1f777871aebe5b97b3fbad29556a238489263401b774",
+              "size": "2593819"
             },
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win32-0.12.0-esp32-20250226.zip",
-              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250226.zip",
-              "checksum": "SHA-256:aaf3c955bb4eb47805a1ba108dfd07a8a56ce720cb40194a354362b5f0961230",
-              "size": "2960226"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win32-0.12.0-esp32-20250422.zip",
+              "archiveFileName": "openocd-esp32-win32-0.12.0-esp32-20250422.zip",
+              "checksum": "SHA-256:ecb4f8533fa9098d10000f5f7e8b8eaa8591015b824b481078ddb2b37e7aa6f2",
+              "size": "2988859"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250226/openocd-esp32-win64-0.12.0-esp32-20250226.zip",
-              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250226.zip",
-              "checksum": "SHA-256:79baf35325117a53093b62f6b9bee677dd12275d7066e3f8a274d2a80e986b6e",
-              "size": "2960225"
+              "url": "https://github.com/espressif/openocd-esp32/releases/download/v0.12.0-esp32-20250422/openocd-esp32-win64-0.12.0-esp32-20250422.zip",
+              "archiveFileName": "openocd-esp32-win64-0.12.0-esp32-20250422.zip",
+              "checksum": "SHA-256:e9eae8e1a8d0e030cd81dcb08394a9137cb7338a6211dfabcdbdfb37b58c5a23",
+              "size": "2988858"
             }
           ]
         },

--- a/package/package_esp32_index.template.json
+++ b/package/package_esp32_index.template.json
@@ -42,7 +42,7 @@
             {
               "packager": "esp32",
               "name": "esp32-arduino-libs",
-              "version": "idf-release_v5.3-8e95ca29-v1"
+              "version": "idf-release_v5.3-eaf03eec-v1"
             },
             {
               "packager": "esp32",
@@ -95,63 +95,63 @@
       "tools": [
         {
           "name": "esp32-arduino-libs",
-          "version": "idf-release_v5.3-8e95ca29-v1",
+          "version": "idf-release_v5.3-eaf03eec-v1",
           "systems": [
             {
               "host": "i686-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "x86_64-mingw32",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "arm64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "x86_64-apple-darwin",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "x86_64-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "i686-pc-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "aarch64-linux-gnu",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             },
             {
               "host": "arm-linux-gnueabihf",
-              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-8e95ca29-v1.zip",
-              "checksum": "SHA-256:9ccfd8f643ffe8f41bbbda8dae57edf2b214dde6c064e24e42162dc6cd759eea",
-              "size": "61762209"
+              "url": "https://github.com/reykada/esp32-arduino-lib-builder/releases/download/idf-release_v5.3/esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "archiveFileName": "esp32-arduino-libs-idf-release_v5.3-eaf03eec-v1.zip",
+              "checksum": "SHA-256:b271c207232e8d5f286391af107e56a281cbf94f4440d402cdebc94c2acad198",
+              "size": "61763087"
             }
           ]
         },


### PR DESCRIPTION
```
lib-builder: master 200d29d
esp-idf: release/v5.3 8bb65e6d85
arduino: idf-release/v5.3 05088466
tinyusb: master 4c1e28126
chmorgan__esp-libhelix-mp3: 1.0.3
espressif__cbor: 0.6.0~1
espressif__esp-dsp: 1.4.12
espressif__esp-modbus: 1.0.17
espressif__esp-nn: 1.1.0
espressif__esp-serial-flasher: 0.0.11
espressif__esp-sr: 1.9.5
espressif__esp-tflite-micro: 1.3.3~1
espressif__esp-zboss-lib: 1.6.3
espressif__esp-zigbee-lib: 1.6.3
espressif__esp32-camera:
espressif__esp_diag_data_store: 1.0.1
espressif__esp_diagnostics: 1.0.2
espressif__esp_encrypted_img: 2.1.0
espressif__esp_insights: 1.0.1
espressif__esp_matter: 1.3.0
espressif__esp_modem: 1.3.0
espressif__esp_rainmaker: 1.5.0
espressif__esp_rcp_update: 1.2.0
espressif__esp_schedule: 1.2.0
espressif__esp_secure_cert_mgr: 2.5.0
espressif__jsmn: 1.1.0
espressif__json_generator: 1.1.2
espressif__json_parser: 1.0.3
espressif__libsodium: 1.0.20~2
espressif__mdns: 1.8.1
espressif__network_provisioning: 1.0.2
espressif__qrcode: 0.1.0~2
espressif__rmaker_common: 1.4.6
joltwallet__littlefs: 1.19.0
```
